### PR TITLE
Fix validation in entry point for urls that contains accented characters

### DIFF
--- a/ampbench_routes.js
+++ b/ampbench_routes.js
@@ -129,6 +129,13 @@ const results_template = fs.readFileSync(__dirname + '/views/results.hbs', 'utf8
 // TODO: WIP20160426 - bulk support routes
 // const multi_url_template = fs.readFileSync(__dirname + '/views/multi_url.hbs', 'utf8');
 
+app.use(function(req, res, next) {
+    if (req.query && req.query.url) {
+        req.query.url = encodeURI(req.query.url);
+    }
+    next();
+});
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // ERRORS
 //


### PR DESCRIPTION
Fixes an issue when consuming the API with url that contains accented characters.

The main issue is with the npm module: valid-url. At valid-url/index.js: ln 28. This is checking for invalid character as referenced in RFC 3986. As the browser encode accented characters I think it make sense to have this middle ware that does it as well.

Way to reproduce the bug:
https://ampbench.appspot.com/validate?url=http://amp.brasil247.com/pt/247/brasil/342817/“Não-gostamos-desse-tipo-de-emprego”,-dizia-Villas-Bôas-sobre-Exército-na-segurança