### PR TITLE
Fix canonical amps generating infinite redirects

### DIFF
--- a/ampbench_handlers.js
+++ b/ampbench_handlers.js
@@ -216,10 +216,12 @@ function validate(route, user_agent, user_agent_name, req, res, on_validate_call
 
                                 if (( // a Canonical?
                                         url_to_validate === parse_amplinks.canonical_url &&
-                                        '' !== parse_amplinks.amphtml_url
+                                        '' !== parse_amplinks.amphtml_url &&
+                                        parse_amplinks.amphtml_url !== url_to_validate
                                     ) || (
                                         '' === parse_amplinks.canonical_url &&
-                                        '' !== parse_amplinks.amphtml_url
+                                        '' !== parse_amplinks.amphtml_url &&
+                                        parse_amplinks.amphtml_url !== url_to_validate
                                     )) {
                                     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
                                     // CASE 1:


### PR DESCRIPTION
- Canonical AMPs, where both the link amphtml and link canonical
  made reference to the page being validated, were triggering
  the application to redirect to validate the amphtml link.
- Added a check if the amphtml link is different from the url
  to validate before issuing the redirect.
- Since, it doesn't issue the redirect anymore, the page is
  is handled by the default validation code.

Fixes #59 