### PR TITLE
Fix tests incorrectly marked as FAIL

### DIFF
--- a/ampbench_lib.js
+++ b/ampbench_lib.js
@@ -313,7 +313,8 @@ class HttpBodySniffer {
                 amphtml_signature:
                     S(this._body).contains('<html ⚡') || S(this._body).contains(' ⚡>') ||
                     S(this._body).contains('<html amp') || S(this._body).contains('<html AMP') ||
-                    S(this._body).contains(' amp>') || S(this._body).contains(' AMP>'),
+                    S(this._body).contains(' amp>') || S(this._body).contains(' AMP>') ||
+                    S(this._body).contains(' amp=') || S(this._body).contains(' AMP='),
                 amphtml_link:
                     S(this._body).contains('link rel="amphtml"'),
                 amphtml_link2:


### PR DESCRIPTION
- Adds code to fix issues on cases such as
  `<html lang="en-US" amp="">`
- Fixes #65 and partially #36