### PR TITLE
Switch to amp-toolbox-cache-url

### DIFF
--- a/amp-story/linter/amp-toolbox-cache-url.d.ts
+++ b/amp-story/linter/amp-toolbox-cache-url.d.ts
@@ -1,0 +1,4 @@
+declare module "amp-toolbox-cache-url" {
+  function createCacheUrl(cacheSuffix: string, url: string): Promise<string>;
+  export = createCacheUrl;
+}

--- a/amp-story/linter/package-lock.json
+++ b/amp-story/linter/package-lock.json
@@ -56,6 +56,22 @@
         "json-schema-traverse": "^0.3.0"
       }
     },
+    "amp-toolbox-cache-url": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/amp-toolbox-cache-url/-/amp-toolbox-cache-url-0.1.0.tgz",
+      "integrity": "sha512-fT7pXZDx15dAVgZB6jP1WHltR+SMOPpoaG/qhOuuUPH8lFTFivQ2+owyLYKAfwkui6Ia3lYqKeTH7UB0VQXZzg==",
+      "requires": {
+        "mime-types": "^2.1.18",
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
+    },
     "amphtml-validator": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/amphtml-validator/-/amphtml-validator-1.0.23.tgz",
@@ -303,7 +319,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "requires": {
         "graceful-readlink": ">= 1.0.0"
@@ -430,7 +446,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -719,13 +735,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -860,7 +876,7 @@
     },
     "pretty-ms": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
@@ -889,7 +905,7 @@
     },
     "promise": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "integrity": "sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=",
       "requires": {
         "asap": "~2.0.3"
@@ -924,7 +940,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -996,7 +1012,7 @@
     },
     "split": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/split/-/split-1.0.0.tgz",
       "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
       "dev": true,
       "requires": {
@@ -1053,7 +1069,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -1148,7 +1164,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/amp-story/linter/package.json
+++ b/amp-story/linter/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "author": "Michael Stillwell <mjs@beebo.org>",
   "dependencies": {
+    "amp-toolbox-cache-url": "^0.1.0",
     "amphtml-validator": "^1.0.23",
     "cheerio": "^1.0.0-rc.2",
     "debug": "^4.0.1",


### PR DESCRIPTION
Use https://www.npmjs.com/package/amp-toolbox-cache-url instead of rolling our own version.