### PR TITLE
Prevent 502 Bad Gateway in response error

### DIFF
--- a/ampbench_lib.js
+++ b/ampbench_lib.js
@@ -984,7 +984,6 @@ function fetch_and_validate_url(validate_url, on_output_callback, as_json) {
                 headers: { 'User-Agent': UA_AMPBENCH },
                 timeout: 3000,
             };
-            console.log(fetchToCurl(`https://${http_options.host}${http_options.path}`, { headers: http_options.headers }));
             let req = http_response.http_client.request(http_options, callback);
             const handler = (err) => {
                 http_response.is_https_cert_ssl_error = err;
@@ -1069,7 +1068,6 @@ function fetch_and_parse_url_for_amplinks(request_url, on_parsed_callback) {
                 headers: { 'User-Agent': UA_AMPBENCH },
                 timeout: 3000,
             };
-            console.log(fetchToCurl(`https://${http_options.host}${http_options.path}`, { headers: http_options.headers }));
             let req = http_response.http_client.request(http_options, callback);
             const handler = (err) => {
                 http_response.is_https_cert_ssl_error = err;
@@ -1240,7 +1238,6 @@ function check_url_is_reachable_with_user_agent(fetch_url, user_agent, callback)
     };
 
     try {
-        console.log(fetchToCurl(fetch_url, options));
         fetch(fetch_url, options)
                 .then(function(res) {
                 // _log_response(res);

--- a/ampbench_routes.js
+++ b/ampbench_routes.js
@@ -251,6 +251,12 @@ app.post('/valid_ua_desktop', (req, res) => {
 });
 
 app.get('/validate', (req, res) => {
+    const t = 15000;
+    res.setTimeout(t, () => {
+        console.log(`Backend timed out; couldn't complete checks in ${t}ms`);
+        res.status(200).send(version_msg('No data was retrieved from AMP validation service.'));
+        res.end();
+    });
     const user_agent = benchlib.UA_MOBILE_ANDROID_CHROME_52; // mobile ua
     const user_agent_name = 'MOBILE'; // mobile ua
     assert_url(req, res); // handle bad url

--- a/package-lock.json
+++ b/package-lock.json
@@ -1537,12 +1537,21 @@
       }
     },
     "follow-redirects": {
-      "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-0.1.0.tgz",
-      "integrity": "sha1-gzP77mXS+oWFJB67E3L8AeWx9nE=",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+      "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
       "requires": {
-        "debug": "^2.2.0",
-        "stream-consume": "^0.1.0"
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -3863,11 +3872,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "stream-consume": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
     },
     "string": {
       "version": "3.3.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint": "^5.6.0",
     "express": "^4.16.3",
     "file-system": "^2.2.2",
-    "follow-redirects": "^0.1.0",
+    "follow-redirects": "^1.6.1",
     "fs": "0.0.1-security",
     "graceful-fs": "^4.1.3",
     "handlebars": "^4.0.12",


### PR DESCRIPTION
This PR adds a bunch of timeouts to the various requests ampbench does--what seemed to be happening was that the nodejs side of things was taking its time doing its checks (more of them are in effect done sequentially). Eventually, the nginx reverse proxy server gave up, and produced the bad gateway error.

The adds 3 second timeouts to various individual requests, and a 15 second timeout for nodejs to come up with some response. (The error message in this case is particular bad, but it's better than 502 bad gateway.)

Fixes #101.

Example comparisons:

https://ampbench-staging.appspot.com/validate?url=https%3A%2F%2Fm.kohls.com%2Fapi%2Famp%2Fproduct%2Fprd-3056467%2Finstant-pot-duo60-7-in-1-programmable-pressure-cooker.jsp — no error
https://ampbench.appspot.com/validate?url=https%3A%2F%2Fm.kohls.com%2Fapi%2Famp%2Fproduct%2Fprd-3056467%2Finstant-pot-duo60-7-in-1-programmable-pressure-cooker.jsp — error

http://ampbench-staging.appspot.com/validate?url=https%3A%2F%2Fwww.washingtonpost.com%2Fgraphics%2F2019%2Fnational%2Famp-stories%2Fgovernment-shutdown-in-photos%2F — no error
http://ampbench.appspot.com/validate?url=https%3A%2F%2Fwww.washingtonpost.com%2Fgraphics%2F2019%2Fnational%2Famp-stories%2Fgovernment-shutdown-in-photos%2F — error

https://ampbench-staging.appspot.com/validate?url=https%3A%2F%2Fwww.washingtonpost.com%2Fgraphics%2F2019%2Fnational%2Famp-stories%2Fwhat-the-shutdown-looks-like-for-furloughed-workers%2F — no error
https://ampbench.appspot.com/validate?url=https%3A%2F%2Fwww.washingtonpost.com%2Fgraphics%2F2019%2Fnational%2Famp-stories%2Fwhat-the-shutdown-looks-like-for-furloughed-workers%2F — error

https://ampbench-staging.appspot.com/validate?url=https%3A%2F%2Fampbyexample.com%2F — no error
https://ampbench.appspot.com/validate?url=https%3A%2F%2Fampbyexample.com%2F — no error