### PR TITLE
Auto update validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,25 +52,6 @@ Even try this from the command-line:
     $ curl http://localhost:8080/api1?url=https://ampbyexample.com/
     $ curl http://localhost:8080/api2?url=https://ampbyexample.com/
 
-#### Requesting an AMPHTML Validator reload from the CDN ([https://cdn.ampproject.org/v0/validator.js](https://cdn.ampproject.org/v0/validator.js))
-
-Use the following URL to ask AMPBench to reload the validator code into memory should an AMP validator version update be available:
-
-    ../command_force_validator_update
-
-For example, for the public hosted AMPBench instance, open:
-
-- [https://ampbench.appspot.com/command_force_validator_update](https://ampbench.appspot.com/command_force_validator_update)
-
-Or for a local development AMPBench instance:
-
-- [http://localhost:8080/command_force_validator_update](http://localhost:8080/command_force_validator_update)
-
-Or, from a terminal command line:
-
-    $ curl https://ampbench.appspot.com/command_force_validator_update
-    $ curl http://localhost:8080/command_force_validator_update
-
 #### Utilities
 
 AMPBench includes some useful debug utility commands that can in some cases help with troubleshooting, such as when a full validation fails on a URL by returning unexpected server responses. 

--- a/amp-story/linter/caches.json
+++ b/amp-story/linter/caches.json
@@ -12,9 +12,17 @@
       "id": "cloudflare",
       "name": "Cloudflare AMP Cache",
       "docs": "https://amp.cloudflare.com/",
-      "cacheDomain": "cdn.cloudflare.com",
+      "cacheDomain": "amp.cloudflare.com",
       "updateCacheApiDomainSuffix": "amp.cloudflare.com",
       "thirdPartyFrameDomainSuffix": "cloudflareamp.net"
+    },
+    {
+      "id": "bing",
+      "name": "Bing AMP Cache",
+      "docs": "https://www.bing.com/webmaster/help/bing-amp-cache-bc1c884c",
+      "cacheDomain": "bing-amp.com",
+      "updateCacheApiDomainSuffix": "bing-amp.com",
+      "thirdPartyFrameDomainSuffix": "bing-amp.net"
     }
   ]
 }

--- a/ampbench_handlers.js
+++ b/ampbench_handlers.js
@@ -32,10 +32,6 @@ function version_msg(msg) {
     return VERSION_STRING + '[' + new Date().toISOString() + '] ' + msg;
 }
 
-function validator_signature() {
-    return '[validator-signature:' + benchlib.lib_amphtml_validator_signature() + ']';
-}
-
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 // app validation check status constants
 //
@@ -428,7 +424,6 @@ function validate(route, user_agent, user_agent_name, req, res, on_validate_call
                                         user_agent_name: benchlib.get_global_user_agent_name(),
                                         // https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
                                         response_timestamp: new Date().toISOString(), // The timezone is always zero UTC offset, as per suffix "Z"
-                                        amphtml_validator_signature: validator_signature().substr(0, 21 + 16) + ']', // only show left 16 chars
                                         http_response: http_response,
                                         http_response_code: http_response.http_response_code,
                                         http_response_statusIsOK: http_response.statusIsOK(),

--- a/ampbench_lib.js
+++ b/ampbench_lib.js
@@ -795,7 +795,7 @@ class HttpBodyParser extends HttpBodySniffer {
 
 const amphtml_validator = require('amphtml-validator');
 var amphtml_validator_instance = null; // cache the instance
-var amphtml_validator_instance_time = Date.now() - (61*60*1000); // 61 minutes ago
+var amphtml_validator_instance_time = Date.now() - (61 * 60 * 1000); // 61 minutes ago
 
 /**
  * @returns {!Object} validatorInstance
@@ -805,19 +805,19 @@ function lib_load_validator(opt_force_reload) { // force reload now redundant
 }
 
 function lib_init_validator(next) {
-  if (amphtml_validator_instance_time < (Date.now() - (60*60*1000))) {
-    amphtml_validator_instance = null;
-  }
-  if (amphtml_validator_instance === null) {
-    console.log('[VALIDATOR REFRESH]: validator not found or out of date, loading new validator');
-    amphtml_validator_instance = amphtml_validator.getInstance().then((instance) => {
-      amphtml_validator_instance = instance;
-      amphtml_validator_instance_time = Date.now();
-      next();
-    });
-  } else {
-    next();
-  }
+    if (amphtml_validator_instance_time < (Date.now() - (60 * 60 * 1000))) {
+        amphtml_validator_instance = null;
+    }
+    if (amphtml_validator_instance === null) {
+        console.log('[VALIDATOR REFRESH]: validator not found or out of date, loading new validator');
+        amphtml_validator_instance = amphtml_validator.getInstance().then((instance) => {
+            amphtml_validator_instance = instance;
+            amphtml_validator_instance_time = Date.now();
+            next();
+        });
+    } else {
+        next();
+    }
 }
 
 /**

--- a/ampbench_routes.js
+++ b/ampbench_routes.js
@@ -41,7 +41,6 @@ function consoleLogHostAndRemoteIP(req) {
 
 function consoleLogRequest(req, check_http_response, amp_url) {
     print_dashes(80);
-    console.log(version_msg(validator_signature()));
     consoleLogHostAndRemoteIP(req);
     console.log(
             '[HTTP: ' + check_http_response.http_response_code + '] ' +
@@ -136,6 +135,10 @@ handlebars.registerHelper('gtag', function(options) {
     if (process.env.GTAG_ID) {
         return options.fn({ gtag_id: process.env.GTAG_ID });
     }
+});
+
+app.use(function (req, res, next) {
+    benchlib.lib_init_validator(next);
 });
 
 // TODO: WIP20160426 - bulk support routes
@@ -454,17 +457,7 @@ app.get('/debug_curl_cli/', (req, res) => {
 // library into a running AMPBench instance
 app.get('/command_force_validator_update', (req, res) => {
     print_dashes(80);
-    console.log(version_msg(validator_signature()));
-    let __res = '[VALIDATOR REFRESH] BEFORE: ' + validator_signature();
-    const on_refresh_complete = (amphtml_validator_signature) => {
-        __res += ' AFTER: ' + amphtml_validator_signature;
-        console.log(__res);
-        let check_http_response = new benchlib.HttpResponse(req.url);
-        check_http_response.setResponse(res);
-        consoleLogRequest(req, check_http_response, req.url);
-        res.status(200).send(__res);
-    };
-    benchlib.lib_refresh_validator_if_stale(on_refresh_complete);
+    res.status(200).send('Command not necessary; the validator is now automatically refreshed every 60 minutes');
 });
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/ampbench_routes.js
+++ b/ampbench_routes.js
@@ -137,7 +137,7 @@ handlebars.registerHelper('gtag', function(options) {
     }
 });
 
-app.use(function (req, res, next) {
+app.use(function(req, res, next) {
     benchlib.lib_init_validator(next);
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,8 @@
     "acorn": {
       "version": "2.7.0",
       "resolved": "http://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
-      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc="
+      "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+      "optional": true
     },
     "acorn-globals": {
       "version": "1.0.9",
@@ -706,7 +707,8 @@
     "cssom": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog=="
+      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+      "optional": true
     },
     "cssstyle": {
       "version": "0.2.37",
@@ -1629,7 +1631,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1647,11 +1650,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1664,15 +1669,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1775,7 +1783,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1785,6 +1794,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1797,17 +1807,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1824,6 +1837,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1896,7 +1910,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1906,6 +1921,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1981,7 +1997,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2011,6 +2028,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2028,6 +2046,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2066,11 +2085,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Auto-updates the validator every hour.

This PR removes a bunch of code, including some potentially useful validator diagnostics. However, the overall structure is a lot simpler now and the lack of an auto-update was causing so many problems that I think it's worth the "risk."

This should fix #97 and #121.

Fix is deployed to https://ampbench-staging.appspot.com/.