### PR TITLE
Add shutdown banner to the top of ampbench.appspot.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "node"
 install: npm install

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ## AMPBench: AMP URL Validation and Troubleshooting
 
+IMPORTANT: The hosted version of ampbench at <https://ampbench.appspot.com/>
+will be shut down on January 31st, 2020. For more information, please see [issue
+#126](https://github.com/ampproject/ampbench/issues/126).
+
 ### Guides
 
 [Walkthrough article: Debug AMP pages with AMPBench, an open source app from the AMP Project.](https://medium.com/@greyling/ampbench-an-amp-url-validation-and-troubleshooting-application-d33ee83df604)

--- a/ampbench_routes.js
+++ b/ampbench_routes.js
@@ -141,6 +141,12 @@ app.use(function(req, res, next) {
     benchlib.lib_init_validator(next);
 });
 
+app.use(function(req, res, next) {
+    // Issue deprecation warning, see https://tools.ietf.org/html/rfc7234#section-5.5
+    res.setHeader('Warning', '299 - "ampbench will be shut down on 2020-01-31, see https://github.com/ampproject/ampbench/issues/126"');
+    next();
+});
+
 // TODO: WIP20160426 - bulk support routes
 // const multi_url_template = fs.readFileSync(__dirname + '/views/multi_url.hbs', 'utf8');
 

--- a/public/css/ampbench.css
+++ b/public/css/ampbench.css
@@ -2,3 +2,12 @@ body {
     background-color: #f3f3f3;
 }
 
+.mdl-components__warning {
+    width: 100%;
+    max-width: 640px;
+    margin: 20px auto;
+    background-color: #FFF9C4;
+    padding: 16px;
+    border-radius: 2px;
+    color: #212121
+}

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -89,6 +89,7 @@
         </div>
 
         <main class="mdl-layout__content">
+            <div class="mdl-components__warning"><b>Note:</b> <tt>ampbench.appspot.com</tt> (this website) will be shut down on 31 January 2020. For more information, alternatives, and to provide feedback, please see <a href="https://github.com/ampproject/ampbench/issues/126">GitHub Issue #126</a>.</div>
             <div class="page-content" style="width:95%; margin:0 auto; padding:20px">
                 <form method="POST" action="/valid">
                     <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label" style="width: 78%;">


### PR DESCRIPTION
Staged at https://ampbench-staging.appspot.com/; should look like this:

![localhost_8080_](https://user-images.githubusercontent.com/51244/68864604-53206500-06e9-11ea-8aa8-2a8a0f0e5f45.png)

Note that before deploying to production, the project needs to be update to "use" [split health checks](https://cloud.google.com/appengine/docs/flexible/java/migrating-to-split-health-checks#enabling_split_health_checks). (They are actually essentially deactivated, but they need to be turned on because GAE...)

Draft of issue text to be circulated separately.