### PR TITLE
Redirect all requests to GitHub source

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 ## AMPBench: AMP URL Validation and Troubleshooting
 
-IMPORTANT: The hosted version of ampbench at <https://ampbench.appspot.com/>
-will be shut down on January 31st, 2020. For more information, please see [issue
-#126](https://github.com/ampproject/ampbench/issues/126).
+### Status
+
+The hosted version of ampbench was shut down in February 2020. For the rationale
+and alternatives, see [issue
+\#126](https://github.com/ampproject/ampbench/issues/126).
+
+There are no plans to remove the source code from its canonical location at
+<https://github.com/ampproject/ampbench,> but if it is important to you, we
+recommend making a copy.
 
 ### Guides
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "preinstall": "cd amp-story/linter && npm install",
-    "start": "node ampbench_main.js",
+    "start": "node redirect-all.js",
     "monitor": "nodemon --watch . --watch views/index.hbs --watch views/results.hbs --ignore 'validator/*.*'",
     "deploy": "gcloud app deploy app.yaml",
     "lint": "eslint --quiet amp*.js",

--- a/redirect-all.js
+++ b/redirect-all.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const http = require("http");
+
+const PORT = process.env.PORT || 8080;
+
+const server = http.createServer((req, res) => {
+  res.statusCode = 301;
+  res.setHeader('Location', 'https://github.com/ampproject/ampbench#status');
+  res.setHeader('Content-type', 'text/plain');
+  res.end('See https://github.com/ampproject/ampbench#status');
+});
+
+server.listen(PORT, () => {
+  console.log(`App listening on port ${PORT}`);
+});


### PR DESCRIPTION
As part of #126 (ampbench shutdown), redirect all requests to the GitHub.

Surprisingly, it looks like it's necessary to run a nodejs server to do this?? Is there any way around this?

/cc @juliantoledo @sebastianbenz 